### PR TITLE
Added option to generate file of N uuids to copy and paste from

### DIFF
--- a/web/templates/uuid.html
+++ b/web/templates/uuid.html
@@ -41,8 +41,12 @@ main{
 <p> ${str(uuid.uuid1())}</p>
 <p> ${str(uuid.uuid1())}</p>
 <p> ${str(uuid.uuid1())}</p>
-<form method=post>
-<p><input type=submit value='Get new UUID'>
+<form method=post enctype="multipart/form-data"><br>
+<p><input type=submit value='Get new UUIDs' name='regenerate'></p>
+<br><br>OR<br><br>
+<p>Create a .txt file with any number of UUIDs</p>
+Enter number of UUIDs to generate: <input type = "text" name = "number"><br><br>
+<p><input type=submit value='Generate file' name='file'>
 <div class="wrapper">
 </div>
 </form>

--- a/web/uuid.cgi
+++ b/web/uuid.cgi
@@ -20,12 +20,24 @@ import codecs
 import uuid
 import shutil
 import textwrap
+import tempfile
 
 __updated__ = '2018-06-29'
 
 
-# cgitb.enable()
+cgitb.enable()
 
+def uuids_many(path, number=100):
+    '''
+    Creates a file with n uuids, one per line
+    '''
+    f = open(path,"w")
+    for n in range(number):
+        f.write(str(uuid.uuid1())+'\n')
+
+def warn(message, color='red'):
+    message = bytes(message, "utf-8")
+    sys.stdout.buffer.write(b'<p style="color:'+bytes(color,"utf-8")+b'">'+message+b'</p>')
 
 method = os.environ.get("REQUEST_METHOD", "GET")
 
@@ -34,10 +46,6 @@ from mako.lookup import TemplateLookup
 
 templates = TemplateLookup(
     directories=['templates'], output_encoding='utf-8')
-
-
-# method = 'POST'
-# method = 'Test'
 
 if method == "GET":  # This is for getting the page
 
@@ -50,9 +58,39 @@ if method == "GET":  # This is for getting the page
         template.render(uuid=uuid))
 
 elif method == "POST":
-    template = templates.get_template("uuid.html")
+    
+    form = cgi.FieldStorage()
 
-    sys.stdout.flush()
-    sys.stdout.buffer.write(b"Content-Type: text/html\n\n")
-    sys.stdout.buffer.write(
-        template.render(uuid=uuid))
+    if "file" in form:
+        tmpfile = '/tmp/tmpfile.txt'
+        try:
+            number = int(form["number"].value)
+        except:
+            number = 0
+        
+        if number < 1:
+            error = "Please enter an integer greater than 0"
+            sys.stdout.flush()
+            sys.stdout.buffer.write(b"Content-Type: text/html\n\n")
+            sys.stdout.buffer.write(b"<!doctype html>\n<html>\n <meta charset='utf-8'>")
+            warn(error)
+            sys.stdout.buffer.write(b'</html>')
+        else:
+
+            filename='uuids.txt'
+            print("Content-Type: text/plain")
+            print("Content-Disposition: attachment; filename="+filename+"\n")
+            path = "/tmp/" + next(tempfile._get_candidate_names()) + ".txt"
+
+            uuids_many(path, number)
+
+            with open(path, "rb") as f:
+                sys.stdout.flush()
+                shutil.copyfileobj(f, sys.stdout.buffer)
+    else:
+        template = templates.get_template("uuid.html")
+
+        sys.stdout.flush()
+        sys.stdout.buffer.write(b"Content-Type: text/html\n\n")
+        sys.stdout.buffer.write(
+            template.render(uuid=uuid))


### PR DESCRIPTION
Often, people work with need to log events where there is no physical sample (or nothing preserved to label).

Previously, there was an option to copy and paste 4 UUIDs at a time from the 'uuid generator' on the labelling VM. However, it takes a long time to do this if you have lots of events.

Therefore, I have added an option where the user specifies the number of UUIDs they want to generate, and a file .txt is created from which they can copy and paste from.